### PR TITLE
carousel--two-rows

### DIFF
--- a/assets/carousel--two-rows.css
+++ b/assets/carousel--two-rows.css
@@ -1,0 +1,131 @@
+/* carousel--two-rows.css */
+.carousel-container {
+    position: relative;
+    padding-top: 150px; /* Increased to prevent overlapping with the navigation */
+}
+
+.carousel-text {
+    text-align: center;
+    position: absolute;
+    width: 100%;
+    top: 0; /* Positioning from the top */
+    left: 0; /* Align to the left edge */
+    z-index: 1; /* To ensure it is above the images */
+    padding: 10px 0; /* Padding around the text for spacing */
+    background: rgba(255, 255, 255, 0.8); /* Semi-transparent white background */
+}
+
+.carousel-text h2 {
+    font-size: 2em; /* Large text size for larger screens */
+    color: rgb(132, 36, 192); /* Purple color */
+    font-family: 'Poppins', sans-serif; /* Modern font */
+    font-weight: bold; /* Bold font weight */
+    margin: 0.25em 0; /* Adjust margin for tighter spacing */
+}
+
+.carousel-text p {
+    font-size: 1.5em; /* Smaller text size for subheading */
+    color: rgb(183, 92, 240);/* Purple color */
+    font-family: 'Poppins', sans-serif; /* Modern font */
+    margin: 0.25em 0; /* Adjust margin for tighter spacing */
+}
+
+.follow-container {
+    /* Use flexbox to align items in a row */
+    display: flex;
+    align-items: center; /* Center items vertically */
+    justify-content: center; /* Center items horizontally */
+    gap: 10px; /* Space between the text and link */
+  }
+  
+  .follow-container a {
+    display: inline-block; /* Inline-block to make it align nicely with text */
+    text-decoration: none; /* Remove underline from links */
+    color: rgb(183, 92, 240);/* Purple color */
+    font-weight: bold; /* Make the link text bold */
+    border-radius: 5px; /* Rounded corners for the link */
+    transition: background-color 0.3s; /* Transition for a hover effect */
+  }
+  
+  .follow-container a:hover {
+    background-color: #e0e0e0; /* Darker grey background on hover */
+  }
+  
+
+.shopify-carousel-container {
+    margin-bottom: 20px;
+}
+
+.carousel {
+    overflow: hidden;
+    width: 100%;
+    white-space: nowrap; 
+    position: relative;
+}
+
+.carousel-cell {
+    display: inline-block;
+    vertical-align: middle;
+    white-space: normal; /* Resets white-space for carousel content */
+}
+
+/* Images styles */
+.carousel img {
+    width: 150px; /* Fixed width for desktop */
+    height: 150px; /* Fixed height for desktop */
+    object-fit: cover;
+    border-radius: 15px;
+    margin: 10px; /* Space between images */
+}
+/* Define keyframe animations for sliding to the left */
+@keyframes slide-left {
+    0% { transform: translate3d(200%, 0, 0); } /* Start from the original position */
+    100% { transform: translate3d(-100%, 0, 0); } /* End by moving left the entire width of the content */
+}
+
+/* Define keyframe animations for sliding to the right */
+@keyframes slide-right {
+    0% { transform: translate3d(-100%, 0, 0); } /* Start from the original position */
+    100% { transform: translate3d(200%, 0, 0); } /* End by moving right the entire width of the content */
+}
+
+/* Apply continuous slide animations to the carousels */
+.upper-row .carousel-cell {
+    animation: slide-left 4s linear infinite; /* Use a duration that ensures smooth continuous motion */
+}
+
+.lower-row .carousel-cell {
+    animation: slide-right 4s linear infinite; /* Use a duration that ensures smooth continuous motion */
+}
+
+/* Carousel setup */
+.upper-row, .lower-row {
+    display: flex;
+    flex-wrap: nowrap; /* Prevent wrapping to the next line */
+}
+
+.carousel-cell {
+    flex: 0 0 auto; /* Do not stretch or shrink the cells */
+}
+
+
+/* Responsive styles for mobile */
+@media screen and (max-width: 480px) {
+    .carousel-container {
+        padding-top: 120px; /* Enough to clear the text above on mobile */
+    }
+
+    .carousel-text h2 {
+        font-size: 1.2em; /* Smaller font size for mobile */
+    }
+
+    .carousel-text p {
+        font-size: 1em; /* Smaller font size for mobile */
+    }
+
+    .carousel img {
+        width: 100px; /* Smaller width for mobile */
+        height: 100px; /* Smaller height for mobile */
+        margin: 5px; /* Smaller margin for mobile */
+    }
+}

--- a/sections/carousel--two-rows.liquid
+++ b/sections/carousel--two-rows.liquid
@@ -1,0 +1,114 @@
+{{ 'carousel--two-rows.css' | asset_url | stylesheet_tag }}
+<!-- Carousel Text -->
+<div class="carousel-container">
+  <div class="carousel-text">
+    <h2>{{ section.settings.heading_text }}</h2>
+    <p>{{ section.settings.subheading_text }}</p>
+    <div class="follow-container">
+        <a href="{{ section.settings.cta_url }}" target="_blank">{{ section.settings.cta_text }}</a>
+      </div>
+      
+  </div>
+
+  <!-- Upper Row Carousel -->
+  <div class="carousel upper-row">
+    {% for block in section.blocks %}
+      {% if block.type == 'upper-image' %}
+        <div class="carousel-cell">
+          <img src="{{ block.settings.image | img_url: '800x' }}" alt="{{ block.settings.image.alt | escape }}">
+        </div>
+      {% endif %}
+    {% endfor %}
+      <!-- Duplicate the images for a continuous loop -->
+  {% for block in section.blocks %}
+    {% if block.type == 'upper-image' %}
+      <div class="carousel-cell">
+        <img src="{{ block.settings.image | img_url: '800x' }}" alt="{{ block.settings.image.alt | escape }}">
+      </div>
+    {% endif %}
+  {% endfor %}
+  </div>
+
+  <!-- Lower Row Carousel -->
+  <div class="carousel lower-row">
+    {% for block in section.blocks %}
+      {% if block.type == 'lower-image' %}
+        <div class="carousel-cell">
+          <img src="{{ block.settings.image | img_url: '800x' }}" alt="{{ block.settings.image.alt | escape }}">
+        </div>
+      {% endif %}
+    {% endfor %}
+      <!-- Duplicate the images for a continuous loop -->
+  {% for block in section.blocks %}
+    {% if block.type == 'lower-image' %}
+      <div class="carousel-cell">
+        <img src="{{ block.settings.image | img_url: '800x' }}" alt="{{ block.settings.image.alt | escape }}">
+      </div>
+    {% endif %}
+  {% endfor %}
+  </div>
+</div>
+
+{% schema %}
+{
+  "name": "Two-Row Carousel",
+  "settings": [
+    {
+      "type": "text",
+      "id": "heading_text",
+      "label": "Heading Text",
+      "default": "MORE THAN 1,25,000"
+    },
+    {
+      "type": "text",
+      "id": "subheading_text",
+      "label": "Subheading Text",
+      "default": "YUMMY GUMMERS"
+    },
+    {
+      "type": "url",
+      "id": "cta_url",
+      "label": "CTA URL"
+    },
+    {
+      "type": "text",
+      "id": "cta_text",
+      "label": "CTA Text",
+      "default": "@yummygumsvitamins"
+    }
+  ],
+  "blocks": [
+    {
+      "type": "upper-image",
+      "name": "Upper Row Image",
+      "settings": [
+        {
+          "type": "image_picker",
+          "id": "image",
+          "label": "Image for Upper Row"
+        }
+      ],
+      "limit": 15 // Set the limit to 15 or any other number based on how many images you want to allow
+    },
+    {
+      "type": "lower-image",
+      "name": "Lower Row Image",
+      "settings": [
+        {
+          "type": "image_picker",
+          "id": "image",
+          "label": "Image for Lower Row"
+        }
+      ],
+      "limit": 15 // Set the limit to 15 or any other number based on how many images you want to allow
+    }
+  ],
+  "max_blocks": 30, // Increase the max_blocks to accommodate the total number of images for upper and lower rows combined
+  "presets": [
+    {
+      "name": "Two-Row Carousel",
+      "category": "Image"
+    }
+  ]
+}
+{% endschema %}

--- a/templates/index.context.in.json
+++ b/templates/index.context.in.json
@@ -1,0 +1,8 @@
+{
+  "parent": "index.json",
+  "context": {
+    "market": "in"
+  },
+  "sections": {
+  }
+}


### PR DESCRIPTION
Issue no : #10 

✅Added a 2 row carousel

Screenshots:

Web view:
![image](https://github.com/dear-digital/shopify-theme-skeleton/assets/88500027/8f99e65e-c37f-429a-839f-f89248c9df6f)

Whole view in Shopify:
![image](https://github.com/dear-digital/shopify-theme-skeleton/assets/88500027/ec8fa733-7507-4771-8990-e542ae61b825)

User can edit the text and link as well:
(Can paste a link in CTA URL field and it will direct you there)
![image](https://github.com/dear-digital/shopify-theme-skeleton/assets/88500027/e5432080-0f89-4d43-917a-9a991b881c0f)

Images as well:
![image](https://github.com/dear-digital/shopify-theme-skeleton/assets/88500027/61d0784e-cfe7-4b33-b95e-2883e36ac90d)

Mobile view:
![image](https://github.com/dear-digital/shopify-theme-skeleton/assets/88500027/046352d2-986f-4ef1-8bb8-48205eecd398)


