### PR TITLE
Enhanced the textarea of Screenshots in BUG_REPORT 

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -47,7 +47,6 @@ body:
     description: If applicable, add screenshots to show the bug.
     placeholder: |
       ![imageName](url.png)
-    render: bash
   validations:
     required: false
     


### PR DESCRIPTION
Issue No : #128

✅Resolved the issue, now the markdown for screenshots textarea is proper.