### PR TITLE
Add svg from Collapsible Section into snippet's folder

### DIFF
--- a/sections/dev__collapsible-content.liquid
+++ b/sections/dev__collapsible-content.liquid
@@ -16,19 +16,7 @@
               {{- block.settings.title -}}
             </span>
             <span class="collapsible-content__icon {{ block.settings.collapsible_icon }}">
-              <svg
-                fill="none"
-                height="24"
-                shape-rendering="geometricPrecision"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path d="M6 9l6 6 6-6"></path>
-              </svg>
+              {% render 'icon-collapsible' %}
             </span>
           </summary>
           <p class="collapsible-content__content {{ block.settings.collapsible_content }}">

--- a/snippets/icon-collapsible.liquid
+++ b/snippets/icon-collapsible.liquid
@@ -1,0 +1,13 @@
+<svg
+  fill="none"
+  height="24"
+  shape-rendering="geometricPrecision"
+  stroke="currentColor"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  stroke-width="1.5"
+  viewBox="0 0 24 24"
+  width="24"
+>
+  <path d="M6 9l6 6 6-6"></path>
+</svg>


### PR DESCRIPTION
Solves Issue no #157 

- Transfered the svg code from collapsible section to a new file as `icon-collapsible.liquid` into snippet's folder!
- Checking after updating:
![image](https://github.com/dear-digital/shopify-theme-skeleton/assets/91179998/8ba94aa3-0444-4492-b8eb-672cce29ee2b)
