### PR TITLE
Added Back To The Top button in Sections

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -105,5 +105,6 @@
       <li id="a11y-refresh-page-message">{{ 'accessibility.refresh_page' | t }}</li>
       <li id="a11y-new-window-message">{{ 'accessibility.link_messages.new_window' | t }}</li>
     </ul>
+    {% section 'dev__back-to-the-top' %}
   </body>
 </html>

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -105,6 +105,5 @@
       <li id="a11y-refresh-page-message">{{ 'accessibility.refresh_page' | t }}</li>
       <li id="a11y-new-window-message">{{ 'accessibility.link_messages.new_window' | t }}</li>
     </ul>
-    {% section 'dev__back-to-the-top' %}
   </body>
 </html>

--- a/sections/dev__back-to-the-top.liquid
+++ b/sections/dev__back-to-the-top.liquid
@@ -1,15 +1,14 @@
-{% assign vertical_offset_for_trigger = 300 %}
-{% assign position_from_bottom = '6em' %}
-
+<section>
 <a id="BackToTop" href="#" title="Back to the top" class="back-to-top hide">
   <i class="arrow"></i>
 </a>
+</section>
 
 <script>
   (function() {
   function trackScroll() {
       var scrolled = window.pageYOffset;
-      var coords = {{ vertical_offset_for_trigger }};
+      var coords = {{ section.settings.vertical_offset_for_trigger }};
 
       if (scrolled > coords) {
       goTopBtn.classList.remove('hide');
@@ -45,7 +44,7 @@
 
     .back-to-top {
       position: fixed;
-      bottom: {{ position_from_bottom }};
+      bottom: {{ section.settings.position_from_bottom }};
       right: 0px;
       text-decoration: none;
       color: #7a7a7a;
@@ -68,3 +67,32 @@
       display: none !important;
     }
 </style>
+
+{% schema %}
+{
+  "name": "Back-to-Top Button",
+  "tag": "section",
+  "class": "section",
+  "settings": [
+    {
+      "type": "text",
+      "id": "vertical_offset_for_trigger",
+      "label": "Vertical Offset for Triggering",
+      "default": "300"
+    },
+    {
+      "type": "text",
+      "id": "position_from_bottom",
+      "label": "Position from the Bottom",
+      "default": "4em"
+    }
+  ],
+  "presets": [
+    {
+      "category": "Custom",
+      "name": "Back to Top Button"
+    }
+  ]
+}
+{% endschema %}
+

--- a/sections/dev__back-to-the-top.liquid
+++ b/sections/dev__back-to-the-top.liquid
@@ -1,0 +1,70 @@
+{% assign vertical_offset_for_trigger = 300 %}
+{% assign position_from_bottom = '6em' %}
+
+<a id="BackToTop" href="#" title="Back to the top" class="back-to-top hide">
+  <i class="arrow"></i>
+</a>
+
+<script>
+  (function() {
+  function trackScroll() {
+      var scrolled = window.pageYOffset;
+      var coords = {{ vertical_offset_for_trigger }};
+
+      if (scrolled > coords) {
+      goTopBtn.classList.remove('hide');
+      }
+      if (scrolled < coords) {
+      goTopBtn.classList.add('hide');
+      }
+  }
+
+  function backToTop() {
+      if (window.pageYOffset > 0) {
+      window.scrollBy(0, -80);
+      setTimeout(backToTop, 0);
+      }
+  }
+
+  var goTopBtn = document.querySelector('.back-to-top');
+
+  window.addEventListener('scroll', trackScroll);
+  goTopBtn.addEventListener('click', backToTop);
+  })();
+</script>
+
+<style>
+  .arrow {
+      display: inline-block;
+      width: 0;
+      height: 0;
+      border-left: 20px solid transparent;
+      border-right: 20px solid transparent;
+      border-bottom: 25px solid #000;
+    }
+
+    .back-to-top {
+      position: fixed;
+      bottom: {{ position_from_bottom }};
+      right: 0px;
+      text-decoration: none;
+      color: #7a7a7a;
+      background-color: #eee;
+      padding: 0.3em;
+      border-top-left-radius: 3px;
+      border-bottom-left-radius: 3px;
+      z-index: 60000;
+      transition: background-color 0.3s, color 0.3s;
+      border-radius: 10px;
+    }
+
+    .back-to-top:hover {
+      text-decoration: none;
+      color: #414141;
+      background-color: #ddd;
+    }
+
+    .hide {
+      display: none !important;
+    }
+</style>

--- a/sections/dev__back-to-the-top.liquid
+++ b/sections/dev__back-to-the-top.liquid
@@ -1,7 +1,7 @@
-<section>
-<a id="BackToTop" href="#" title="Back to the top" class="back-to-top hide">
-  <i class="arrow"></i>
-</a>
+<section class="back-to-top_section_classes">
+  <a id="BackToTop" href="#" title="Back to the top" class="back-to-top_classes back-to-top hide">
+    <i class="arrow_classes arrow"></i>
+  </a>
 </section>
 
 <script>
@@ -34,38 +34,38 @@
 
 <style>
   .arrow {
-      display: inline-block;
-      width: 0;
-      height: 0;
-      border-left: 20px solid transparent;
-      border-right: 20px solid transparent;
-      border-bottom: 25px solid #000;
-    }
+    display: inline-block;
+    width: 0;
+    height: 0;
+    border-left: 20px solid transparent;
+    border-right: 20px solid transparent;
+    border-bottom: 25px solid #000;
+  }
 
-    .back-to-top {
-      position: fixed;
-      bottom: {{ section.settings.position_from_bottom }};
-      right: 0px;
-      text-decoration: none;
-      color: #7a7a7a;
-      background-color: #eee;
-      padding: 0.3em;
-      border-top-left-radius: 3px;
-      border-bottom-left-radius: 3px;
-      z-index: 60000;
-      transition: background-color 0.3s, color 0.3s;
-      border-radius: 10px;
-    }
+  .back-to-top {
+    position: fixed;
+    bottom: {{ section.settings.position_from_bottom }};
+    right: 0px;
+    text-decoration: none;
+    color: #7a7a7a;
+    background-color: #eee;
+    padding: 0.3em;
+    border-top-left-radius: 3px;
+    border-bottom-left-radius: 3px;
+    z-index: 60000;
+    transition: background-color 0.3s, color 0.3s;
+    border-radius: 10px;
+  }
 
-    .back-to-top:hover {
-      text-decoration: none;
-      color: #414141;
-      background-color: #ddd;
-    }
+  .back-to-top:hover {
+    text-decoration: none;
+    color: #414141;
+    background-color: #ddd;
+  }
 
-    .hide {
-      display: none !important;
-    }
+  .hide {
+    display: none !important;
+  }
 </style>
 
 {% schema %}
@@ -95,4 +95,3 @@
   ]
 }
 {% endschema %}
-

--- a/sections/dev__back-to-the-top.liquid
+++ b/sections/dev__back-to-the-top.liquid
@@ -1,72 +1,51 @@
-<section class="back-to-top_section_classes">
-  <a id="BackToTop" href="#" title="Back to the top" class="back-to-top_classes back-to-top hide">
-    <i class="arrow_classes arrow"></i>
+<section class="back-to-top_section_classes {{ section.settings.back-to-top_section_classes }}">
+  <a
+    id="BackToTop"
+    href="#"
+    title="Back to the top"
+    class="back-to-top_classes {{ section.settings.back-to-top_classes }}"
+  >
+    <i class="arrow_classes {{ section.settings.arrow_classes }}"></i>
   </a>
 </section>
 
 <script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var goTopBtn = document.querySelector('.back-to-top_classes');
+    goTopBtn.style.display = 'none';
+  });
+
   (function() {
-  function trackScroll() {
+    function trackScroll() {
       var scrolled = window.pageYOffset;
-      var coords = {{ section.settings.vertical_offset_for_trigger }};
+      var coords = 300;
+      var goTopBtn = document.querySelector('.back-to-top_classes');
 
       if (scrolled > coords) {
-      goTopBtn.classList.remove('hide');
+        goTopBtn.style.display = 'block';
+      } else {
+        goTopBtn.style.display = 'none'; // Hide the arrow when scrolling up
       }
-      if (scrolled < coords) {
-      goTopBtn.classList.add('hide');
-      }
-  }
+    }
 
-  function backToTop() {
+    function backToTop() {
+      var goTopBtn = document.querySelector('.back-to-top_classes');
       if (window.pageYOffset > 0) {
-      window.scrollBy(0, -80);
-      setTimeout(backToTop, 0);
+        window.scrollBy(0, -80);
+        setTimeout(function() {
+          goTopBtn.style.display = 'none';
+        }, 0);
       }
-  }
+    }
 
-  var goTopBtn = document.querySelector('.back-to-top');
+    window.addEventListener('scroll', trackScroll);
 
-  window.addEventListener('scroll', trackScroll);
-  goTopBtn.addEventListener('click', backToTop);
+    document.addEventListener('DOMContentLoaded', function() {
+      var goTopBtn = document.querySelector('.back-to-top_classes');
+      goTopBtn.addEventListener('click', backToTop);
+    });
   })();
 </script>
-
-<style>
-  .arrow {
-    display: inline-block;
-    width: 0;
-    height: 0;
-    border-left: 20px solid transparent;
-    border-right: 20px solid transparent;
-    border-bottom: 25px solid #000;
-  }
-
-  .back-to-top {
-    position: fixed;
-    bottom: {{ section.settings.position_from_bottom }};
-    right: 0px;
-    text-decoration: none;
-    color: #7a7a7a;
-    background-color: #eee;
-    padding: 0.3em;
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
-    z-index: 60000;
-    transition: background-color 0.3s, color 0.3s;
-    border-radius: 10px;
-  }
-
-  .back-to-top:hover {
-    text-decoration: none;
-    color: #414141;
-    background-color: #ddd;
-  }
-
-  .hide {
-    display: none !important;
-  }
-</style>
 
 {% schema %}
 {
@@ -75,16 +54,25 @@
   "class": "section",
   "settings": [
     {
-      "type": "text",
-      "id": "vertical_offset_for_trigger",
-      "label": "Vertical Offset for Triggering",
-      "default": "300"
+      "type": "header",
+      "content": "Tailwind Styling"
     },
     {
-      "type": "text",
-      "id": "position_from_bottom",
-      "label": "Position from the Bottom",
-      "default": "4em"
+      "type": "textarea",
+      "id": "back-to-top_section_classes",
+      "label": "Section Styling"
+    },
+    {
+      "type": "textarea",
+      "id": "back-to-top_classes",
+      "label": "Back to Top Section Styling",
+      "default": "fixed no-underline text-[#7a7a7a] bg-[#eee] z-[60000] transition-[#eee] duration-[0.3s,#7a7a7a] delay-[0.3s] p-[0.3em] rounded-tl-[3px] rounded-bl-[3px] rounded-[10px] right-0 bottom-[4em] hover:no-underline hover:text-[#414141] hover:bg-[#ddd]"
+    },
+    {
+      "type": "textarea",
+      "id": "arrow_classes",
+      "label": "Arrow Icon Styling",
+      "default": "inline-block w-0 h-0 border-b-[25px] border-b-black border-x-[20px] border-x-transparent border-solid"
     }
   ],
   "presets": [

--- a/sections/dev__back-to-the-top.liquid
+++ b/sections/dev__back-to-the-top.liquid
@@ -9,42 +9,45 @@
   </a>
 </section>
 
+<style>
+  .back-to-top_classes {
+    transition: opacity 0.3s;
+    opacity: 0;
+    text-decoration: none;
+  }
+  
+  .back-to-top_classes.show {
+    opacity: 1;
+  }
+</style>
+
 <script>
   document.addEventListener('DOMContentLoaded', function () {
     var goTopBtn = document.querySelector('.back-to-top_classes');
-    goTopBtn.style.display = 'none';
-  });
-
-  (function() {
+    if (!goTopBtn) return; // Check if button exists
+  
     function trackScroll() {
       var scrolled = window.pageYOffset;
       var coords = 300;
-      var goTopBtn = document.querySelector('.back-to-top_classes');
-
       if (scrolled > coords) {
-        goTopBtn.style.display = 'block';
+        goTopBtn.classList.add('show'); // Use CSS class for showing/hiding
       } else {
-        goTopBtn.style.display = 'none'; // Hide the arrow when scrolling up
+        goTopBtn.classList.remove('show');
       }
     }
-
+  
     function backToTop() {
-      var goTopBtn = document.querySelector('.back-to-top_classes');
       if (window.pageYOffset > 0) {
         window.scrollBy(0, -80);
-        setTimeout(function() {
-          goTopBtn.style.display = 'none';
-        }, 0);
+        requestAnimationFrame(backToTop); // Smooth scrolling
+      } else {
+        goTopBtn.classList.remove('show'); // Ensure it's hidden after reaching the top
       }
     }
-
-    window.addEventListener('scroll', trackScroll);
-
-    document.addEventListener('DOMContentLoaded', function() {
-      var goTopBtn = document.querySelector('.back-to-top_classes');
-      goTopBtn.addEventListener('click', backToTop);
-    });
-  })();
+  
+    window.addEventListener('scroll', trackScroll); // Consider debouncing this
+    goTopBtn.addEventListener('click', backToTop);
+  });
 </script>
 
 {% schema %}


### PR DESCRIPTION
## Pull Request for Issue No : #183 

### Type of Pull Request: 

<!-- Put x in [ ] in order to mark them as check. e.g. [x] will be marked as check -->

- [x] Feature Request.
- [ ] Bug Request.
- [ ] Report a security vulnerability.

### PR Summary: 

- Implemented a "Back to Top" button in the theme.liquid file using `dev__back-to-the-top.liquid` file. This feature will enhance user experience by allowing them to easily navigate back to the top of the page with a single click.
- Also added necessary dynamic Tailwind configuration settings.

### What approach did you take?

Added Back-to-Top button with Tailwind CSS styling and some JavaScript logic to handle its visibility based on the scroll position. 

### Demo links/Screenshots


https://github.com/dear-digital/shopify-theme-skeleton/assets/91179998/49dc0ce5-77a7-4b13-95e2-f72c407d6f49



### Code Review Checklist

Please review the following aspects during the code review:

- [x] Added PR summary
- [x] Followed theme code principles
- [x] Checked for any warnings by shopify theme check
- [x] Tested for Responsive
- [x] Tested on multiple browsers

### Information Completeness

<!-- Put x in [ ] in order to mark them as check. e.g. [x] will be marked as check -->

- [x] Yes, I have provided all the correct and necessary information.