### PR TITLE
Updated Text-Image and Added Text Image Overlay Section

### DIFF
--- a/sections/dev__image-text-overlay.liquid
+++ b/sections/dev__image-text-overlay.liquid
@@ -1,0 +1,95 @@
+<div class="image-text-overlay-container {{ section.settings.image-text-overlay-container }}">
+    {%- assign image_url_width = section.settings.image_url_width -%}
+    {%- assign image_tag_styles_class = section.settings.image-text-overlay-image-tag -%}
+    {% if section.settings.image %}
+        {{ section.settings.image | image_url: width: image_url_width | image_tag: class: image_tag_styles_class }}
+    {% else %}
+        {{ 'product-1' | placeholder_svg_tag }}
+    {% endif %}
+  
+  <div class="image-text-overlay-content {{ section.settings.image-text-overlay-content }}">
+    <h2 class="image-text-overlay-title {{ section.settings.image-text-overlay-title }}">
+    {{ section.settings.main_title }}
+    </h2>
+    <div class="image-text-overlay-description {{ section.settings.image-text-overlay-description }}">
+    <p>{{ section.settings.content }}</p>
+    </div>
+  </div>
+</div>
+
+{% schema %}
+{
+  "name": "Image with Text Overlay",
+  "settings": [
+    {
+      "type": "textarea",
+      "label": "Main Title",
+      "id": "main_title",
+      "default": "Shopify developer documentation"
+    },
+    {
+      "type": "textarea",
+      "label": "Content",
+      "id": "content",
+      "default": "Learn how to build an app, theme, custom storefront, or marketplace. Whether you’re just getting started, deep in the development process, or ready to distribute and monetize your work, Shopify’s docs, dev tools and frameworks make building easy and efficient."
+    },
+    {
+      "type": "image_picker",
+      "id": "image",
+      "label": "Add a Image"
+    },
+    {
+      "type": "text",
+      "label": "Image Alt Text",
+      "id": "alt_text",
+      "default": "Image Alt Text"
+    },
+    {
+      "type": "text",
+      "id": "image_url_width",
+      "label": "Image URL width",
+      "default": "1000"
+    },
+    {
+      "type": "header",
+      "content": "Styling"
+    },
+    {
+      "type": "textarea",
+      "id": "image-text-overlay-container",
+      "label": "Image Text Container",
+      "default": "relative h-[300px] md:h-[500px]"
+    },
+    {
+      "type": "textarea",
+      "id": "image-text-overlay-image-tag",
+      "label": "Overlay Image Style",
+      "default": "h-full w-full object-cover"
+    },
+    {
+      "type": "textarea",
+      "id": "image-text-overlay-content",
+      "label": "Image Content Style",
+      "default": "absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
+    },
+    {
+      "type": "textarea",
+      "id": "image-text-overlay-title",
+      "label": "Title Style",
+      "default": "text-6xl text-gray-700 font-bold mb-10 max-md:text-4xl max-md:mb-2"
+    },
+    {
+      "type": "textarea",
+      "id": "image-text-overlay-description",
+      "label": "Description Style",
+      "default": "text-lg text-gray-600 mb-5"
+    }
+  ],
+  "presets": [
+    {
+      "name": "Image with Text Overlay",
+      "category": "Custom"
+    }
+  ]
+}
+{% endschema %}

--- a/sections/dev__image-text.liquid
+++ b/sections/dev__image-text.liquid
@@ -23,7 +23,7 @@
 
 {% schema %}
 {
-  "name": "Image with Text Overlay",
+  "name": "Image and Text Container",
   "settings": [
     {
       "type": "text",
@@ -115,7 +115,7 @@
   ],
   "presets": [
     {
-      "name": "Image with Text Overlay",
+      "name": "Image and Text Container",
       "category": "Custom"
     }
   ]


### PR DESCRIPTION
## Pull Request for Issue No : #248 

### Type of Pull Request: 

<!-- Put x in [ ] in order to mark them as check. e.g. [x] will be marked as check -->

- [x] Feature Request.
- [ ] Bug Request.
- [ ] Report a security vulnerability.

### PR Summary: 

I have implemented the requested feature by introducing a new section named "Image Text Overlay" to the theme. This section allows users to overlay text on an image, ensuring that the text is positioned correctly over the image and that the height of the image is contained within the container. Additionally, I have renamed the existing "Image Text" section schema to "Image Text Container" to reflect its purpose accurately.

### What approach did you take?

I followed the provided feature description and created a new Liquid template file named `dev__image-text-overlay.liquid` to handle the functionality of the **"Image Text Overlay"** section. I also made modifications to the existing `dev__image-text.liquid` file, renaming its schema to **"Image Text Container"** and ensuring that it aligns with the expected behavior.

### Demo links/Screenshots

Now you can see separated Presets for Both Sections:

![image](https://github.com/dear-digital/shopify-theme-skeleton/assets/70633140/864fe276-d193-4137-a463-ba357437c0ba)

<!-- Include links or screenshots showcasing the changes made in the demo store. -->

### Code Review Checklist

Please review the following aspects during the code review:

- [x] Added PR summary
- [x] Followed theme code principles
- [ ] Checked for any warnings by shopify theme check
- [x] Tested for Responsive
- [ ] Tested on multiple browsers

### Information Completeness

<!-- Put x in [ ] in order to mark them as check. e.g. [x] will be marked as check -->

- [x] Yes, I have provided all the correct and necessary information.