### PR TITLE
Adding Marquee Text in Global Blocks 

### DIFF
--- a/blocks/marquee.liquid
+++ b/blocks/marquee.liquid
@@ -1,0 +1,90 @@
+<div class="{{ block.settings.marquee_container_classes }}">
+    <div class="{{ block.settings.marquee_content_classes }}">
+      {% for i in (1..block.settings.marquee_repeat_count) %}
+        {{ block.settings.marquee_text -}}
+        {%- unless forloop.last %} • {% endunless %}
+      {% endfor %}
+    </div>
+  </div>
+  
+  <style>
+    @keyframes animation-marquee {
+      {{ block.settings.marquee_animation }}
+    }
+  
+    .animation-marquee {
+       {{ block.settings.marquee_animation_time }};
+    }
+  
+    .animation-marquee:hover {
+        {{ block.settings.marquee_animation_hover }};
+    }
+  </style>
+  
+  {% schema %}
+  {
+    "name": "Marquee Text",
+    "settings": [
+      {
+        "type": "text",
+        "id": "marquee_text",
+        "label": "Marquee Text",
+        "default": "FASHION FOR ALL "
+      },
+      {
+        "type": "header",
+        "content": "Styling Classes"
+      },
+      {
+        "type": "text",
+        "id": "marquee_container_classes",
+        "label": "Marquee Container Classes",
+        "default": "whitespace-nowrap w-full p-5 bg-blue-100"
+      },
+      {
+        "type": "text",
+        "id": "marquee_content_classes",
+        "label": "Marquee Content Classes",
+        "default": "inline-block animation-marquee text-2xl text-blue-900 font-bold"
+      },
+      {
+        "type": "number",
+        "id": "marquee_repeat_count",
+        "label": "Number of Repeats",
+        "default": 5
+      },
+      {
+        "type": "header",
+        "content": "Keyframe Animation"
+      },
+      {
+        "type": "textarea",
+        "id": "marquee_animation",
+        "label": "Marquee Animation",
+        "default": "0% { transform: translateX(100%); }\n100% { transform: translateX(-100%); }\n infinite { transform: translateX(-100%); }        "
+      },
+      {
+        "type": "textarea",
+        "id": "marquee_animation_time",
+        "label": "Marquee Animation Time",
+        "default": "animation: animation-marquee 10s linear infinite;"
+      },
+      {
+        "type": "textarea",
+        "id": "marquee_animation_hover",
+        "label": "Marquee Animation Hover",
+        "default": "animation-play-state: paused;"
+      },
+      {
+        "type": "header",
+        "content": "Presets"
+      }
+    ],
+    "presets": [
+      {
+        "name": "Marquee Text"
+      }
+    ]
+  }
+  {% endschema %}
+  


### PR DESCRIPTION
## Pull Request for Issue No : #250 

### Type of Pull Request: 

<!-- Put x in [ ] in order to mark them as check. e.g. [x] will be marked as check -->

- [x] Feature Request.
- [ ] Bug Request.
- [ ] Report a security vulnerability.

### PR Summary: 
Added a marquee text block file in the blocks folder, the number of repeats and the text can be set and changed by user. 
<!-- Provide a detailed description of the changes made. Specify modified files and highlight specific lines of code. -->

### Demo links/Screenshots

https://github.com/dear-digital/shopify-theme-skeleton/assets/88500027/0088bf8a-136d-45ca-8480-6a32b7baec09


<!-- Include links or screenshots showcasing the changes made in the demo store. -->

### Code Review Checklist

Please review the following aspects during the code review:

- [x] Added PR summary
- [x] Followed theme code principles
- [x] Checked for any warnings by shopify theme check
- [x] Tested for Responsive
- [x] Tested on multiple browsers

### Information Completeness

<!-- Put x in [ ] in order to mark them as check. e.g. [x] will be marked as check -->

- [x] Yes, I have provided all the correct and necessary information.